### PR TITLE
Include javadoc in package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,12 @@
           <artifactId>maven-project-info-reports-plugin</artifactId>
           <version>3.0.0</version>
         </plugin>
+        <!-- include javadoc -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.2.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
Include `-javadoc.jar` in package file.

- Generate Javadocs As Part Of Project Reports
https://maven.apache.org/plugins/maven-javadoc-plugin/usage.html
